### PR TITLE
Added support for own hostnames and pathStyle Requests

### DIFF
--- a/lib/uber-s3/response.rb
+++ b/lib/uber-s3/response.rb
@@ -27,7 +27,7 @@ class UberS3
       doc = Util::XmlDocument.new(body)
       
       self.error_key      = doc.xpath('//Error/Code').first.text
-      self.error_message  = doc.xpath('//Error/Message').first.text
+      self.error_message  = doc.xpath('//Error/Message').first.text if doc.xpath('//Error/Message').first
       
       error_klass = instance_eval("Error::#{error_key}") rescue nil
       


### PR DESCRIPTION
Added support for own hostnames and pathStyle Requests in order to use "third-party" s3 services. (e.g. ceph or swift).  

```
      s3 = UberS3.new({
                          :access_key         => 'secretkey',
                          :secret_access_key  => 'secret',
                          :bucket             => 'testbucket3',
                          :adapter            => :em_http_fibered,
                          :pathStyle            => true,
                          :host                 => '127.0.0.1:80'
      })
```

If "host" oder "pathStyle" are not set the client connects to s3.amazonaws.com as usual and used dns-style requests on buckets.
