### PR TITLE
[authentication] OpenSSL::Digest::Digest is deprecated.

### DIFF
--- a/lib/uber-s3/authorization.rb
+++ b/lib/uber-s3/authorization.rb
@@ -21,7 +21,7 @@ class UberS3
                                  "#{req_canonical_amz_headers}"+
                                  "#{req_canonical_resource}"
       
-      digest = OpenSSL::Digest::Digest.new('sha1')
+      digest = OpenSSL::Digest.new('sha1')
       [OpenSSL::HMAC.digest(digest, client.connection.secret_access_key, canonical_string_to_sign)].pack("m").strip
     end
     


### PR DESCRIPTION
Fixes output of "Digest::Digest is deprecated; use Digest".

Deprecated in RUBY_VERSION ~> 1.8.7:
https://github.com/ruby/ruby/blob/v1_8_7_374/ext/openssl/lib/openssl/digest.rb#L51-L57
OpenSSL::Digest.new introduced in 1.8.6-p5000:
https://github.com/ruby/ruby/commit/00be63fca5e636383207c8916cce8c61b2059985
