### PR TITLE
Add a max_keys parameter to bucket fetch.

### DIFF
--- a/lib/uber-s3/bucket.rb
+++ b/lib/uber-s3/bucket.rb
@@ -54,11 +54,10 @@ class UberS3
         self.objects  = []
       end
       
-      def fetch(marker=nil)
+      def fetch(marker=nil, max_keys=500)
         @objects = []
 
-        default_max_keys = 500
-        response = bucket.connection.get("/?prefix=#{CGI.escape(key)}&marker=#{marker}&max-keys=#{default_max_keys}")        
+        response = bucket.connection.get("/?prefix=#{CGI.escape(key)}&marker=#{marker}&max-keys=#{max_keys}")        
 
         @objects = parse_contents(response.body)
       end


### PR DESCRIPTION
Allows client code to configure the fetch batch size.
