### PR TITLE
Upgraded mime-types, fixed url underscores, fix blank? not defined

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,8 @@ GIT
 PATH
   remote: .
   specs:
-    uber-s3 (0.2.3)
-      mime-types (~> 1.17)
+    uber-s3 (0.2.4)
+      mime-types
 
 GEM
   remote: http://rubygems.org/
@@ -36,7 +36,7 @@ GEM
     http_parser.rb (0.5.3)
     http_parser.rb (0.5.3-java)
     method_source (0.7.1)
-    mime-types (1.19)
+    mime-types (2.4.3)
     pry (0.9.8.4)
       coderay (~> 1.0.5)
       method_source (~> 0.7.1)

--- a/lib/uber-s3/connection.rb
+++ b/lib/uber-s3/connection.rb
@@ -49,7 +49,7 @@ class UberS3
           headers['Authorization'] = "AWS #{access_key}:#{signature}"
           
           # Make the request
-					if self.region.blank?
+					if self.region.nil?
 						url = "http://#{s3.bucket}.s3.amazonaws.com/#{path}"
 					else
 						url = "http://#{s3.bucket}.s3-#{self.region}.amazonaws.com/#{path}"

--- a/lib/uber-s3/connection/net_http.rb
+++ b/lib/uber-s3/connection/net_http.rb
@@ -9,13 +9,13 @@ module UberS3::Connection
         headers['Accept-Encoding'] = 'gzip, deflate'
       end
       
-      self.uri = URI.parse(url)
+      self.uri = URI.parse(url.gsub('_','-'))
 
       # Init and open a HTTP connection
       http_connect! if http.nil? || !http.started?
 
       req_klass = instance_eval("Net::HTTP::"+verb.to_s.capitalize)
-      req = req_klass.new(uri.to_s, headers)
+      req = req_klass.new(url, headers)
 
       req.body = body if !body.nil? && !body.empty?
 

--- a/uber-s3.gemspec
+++ b/uber-s3.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files        = Dir['README.md', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency('mime-types', ['~> 1.17'])
+  s.add_dependency('mime-types') # , ['~> 1.17'])
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', ['~> 2.7.0'])


### PR DESCRIPTION
DO NOT MERGE....

Hi!

You probably don't want to merge this PR outright, but I hope it gives you some ideas. I had to fork your repo and make these changes to get them to work for a project I'm working on. The issues were:
1) it's a Ruby only system (not Rails), so ".blank?" isn't defined.
2) We have some S3 buckets that pre-date their requirement to NOT use underscores. The URI.parse() method was blowing up with URLs that have underscores. Turns out the uri object is only needed to pull out the host and port for the connect, and otherwise the req_klass just connects to the URL string, so the changes here allowed it to work even if there are underscores in the subdomain (which can happen with older S3 buckets)
3) The mime-types change is probably not necessary. I had a Bundler error early on, but it seems to work fine with 1.19 or 2.4.3, so that part isn't important.

Anyway, if you like, I can clean up #1 and #2 so that they are merge-able... i.e. not just check for nil but also check for empty... maybe something like: self.region.to_s.empty? which would work if self.region is nil or self.region is an empty string.
